### PR TITLE
Do not call superclass disconnect if not connected

### DIFF
--- a/redis/async_connection.py
+++ b/redis/async_connection.py
@@ -245,10 +245,11 @@ class AsyncConnection(Connection):
 
     def disconnect(self):
         "Disconnects from the Redis server"
-        super(AsyncConnection, self).disconnect()
-
         if self._iostream is None:
             return
+
+        super(AsyncConnection, self).disconnect()
+
         try:
             self._iostream.close()
         except socket.error:


### PR DESCRIPTION
redis client will call disconnect on an unconnected
connection which was causing the AsyncHiredisParser
to bomb out on a None iostream.